### PR TITLE
Change "diningroom" to "dining room".

### DIFF
--- a/src/epub/text/chapter-3-4.xhtml
+++ b/src/epub/text/chapter-3-4.xhtml
@@ -46,7 +46,7 @@
 				<p>“You have brought some news, doctor?”</p>
 				<p><abbr>Dr.</abbr> Monygham blurted it all out at once, in the rough. For some time after he had done, the <i xml:lang="es-ES">administrador</i> of the San Tome mine remained looking at him without a word. <abbr>Mrs.</abbr> Gould sank into a low chair with her hands lying on her lap. A silence reigned between those three motionless persons. Then Charles Gould spoke⁠—</p>
 				<p>“You must want some breakfast.”</p>
-				<p>He stood aside to let his wife pass first. She caught up her husband’s hand and pressed it as she went out, raising her handkerchief to her eyes. The sight of her husband had brought Antonia’s position to her mind, and she could not contain her tears at the thought of the poor girl. When she rejoined the two men in the diningroom after having bathed her face, Charles Gould was saying to the doctor across the table⁠—</p>
+				<p>He stood aside to let his wife pass first. She caught up her husband’s hand and pressed it as she went out, raising her handkerchief to her eyes. The sight of her husband had brought Antonia’s position to her mind, and she could not contain her tears at the thought of the poor girl. When she rejoined the two men in the dining room after having bathed her face, Charles Gould was saying to the doctor across the table⁠—</p>
 				<p>“No, there does not seem any room for doubt.”</p>
 				<p>And the doctor assented.</p>
 				<p>“No, I don’t see myself how we could question that wretched Hirsch’s tale. It’s only too true, I fear.”</p>


### PR DESCRIPTION
In the original, it was published as "dining-room".
https://babel.hathitrust.org/cgi/pt?id=osu.32435018425587&view=1up&seq=327

But I changed it to "dining room" with a space because that's what's in a modern dictionary.
https://www.merriam-webster.com/dictionary/dining%20room